### PR TITLE
load stored wallets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+quote_type = single

--- a/src/contexts/Account.tsx
+++ b/src/contexts/Account.tsx
@@ -1,7 +1,7 @@
-import { Account, WalletMetadata } from "@polkadot-onboard/core";
-import type { Signer } from "@polkadot/api/types";
-import React, { useContext, createContext, useState, useEffect } from "react";
-import { useWallets } from "./Wallets";
+import { Account, WalletMetadata } from '@polkadot-onboard/core';
+import type { Signer } from '@polkadot/api/types';
+import React, { useContext, createContext, useState, useEffect } from 'react';
+import { useWallets } from './Wallets';
 
 export type SigningAccount = {
   account: Account;
@@ -18,7 +18,7 @@ export const useAccount = () => useContext(accountContext);
  * Provides a local storage utility class to store the connected account address.
  */
 export class AccountStorage {
-  static CONNECTED_ADRR_STORAGE_KEY = "connectedAddress";
+  static CONNECTED_ADRR_STORAGE_KEY = 'connectedAddress';
   static getConnectedAddress = () =>
     localStorage.getItem(this.CONNECTED_ADRR_STORAGE_KEY);
   static setConnectedAddress = (address: string) =>
@@ -48,7 +48,7 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
         signer,
         metadata: { title },
       } = wallet;
-      if (signer && walletState[title] === "connected") {
+      if (signer && walletState[title] === 'connected') {
         let walletSigningAccounts = {};
         let walletsAccounts = await wallet.getAccounts();
         if (walletsAccounts.length > 0) {
@@ -70,7 +70,7 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
     const {
       sourceMetadata: { title },
     } = signingAccount;
-    return walletState[title] === "connected";
+    return walletState[title] === 'connected';
   };
 
   const setConnectedAccount = (signingAccount: SigningAccount) => {
@@ -113,3 +113,4 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
 };
 
 export default AccountProvider;
+

--- a/src/contexts/Account.tsx
+++ b/src/contexts/Account.tsx
@@ -1,7 +1,7 @@
-import { Account, WalletMetadata } from '@polkadot-onboard/core';
-import type { Signer } from '@polkadot/api/types';
-import React, { useContext, createContext, useState, useEffect } from 'react';
-import { useWallets } from './Wallets';
+import { Account, WalletMetadata } from "@polkadot-onboard/core";
+import type { Signer } from "@polkadot/api/types";
+import React, { useContext, createContext, useState, useEffect } from "react";
+import { useWallets } from "./Wallets";
 
 export type SigningAccount = {
   account: Account;
@@ -18,7 +18,7 @@ export const useAccount = () => useContext(accountContext);
  * Provides a local storage utility class to store the connected account address.
  */
 export class AccountStorage {
-  static CONNECTED_ADRR_STORAGE_KEY = 'connectedAddress';
+  static CONNECTED_ADRR_STORAGE_KEY = "connectedAddress";
   static getConnectedAddress = () =>
     localStorage.getItem(this.CONNECTED_ADRR_STORAGE_KEY);
   static setConnectedAddress = (address: string) =>
@@ -48,7 +48,7 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
         signer,
         metadata: { title },
       } = wallet;
-      if (signer && walletState[title] === 'connected') {
+      if (signer && walletState[title] === "connected") {
         let walletSigningAccounts = {};
         let walletsAccounts = await wallet.getAccounts();
         if (walletsAccounts.length > 0) {
@@ -70,7 +70,7 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
     const {
       sourceMetadata: { title },
     } = signingAccount;
-    return walletState[title] === 'connected';
+    return walletState[title] === "connected";
   };
 
   const setConnectedAccount = (signingAccount: SigningAccount) => {
@@ -78,13 +78,16 @@ const AccountProvider = ({ children }: { children: React.ReactNode }) => {
     _setConnectedAccount(signingAccount);
   };
 
+  const storedConnectedAddress = AccountStorage.getConnectedAddress();
   useEffect(() => {
-    loadConnectedAccount().then((signingAccount: SigningAccount | null) => {
-      if (signingAccount) {
-        setConnectedAccount(signingAccount);
-      }
-    });
-  }, [AccountStorage.getConnectedAddress()]);
+    if (storedConnectedAddress) {
+      loadConnectedAccount().then((signingAccount: SigningAccount | null) => {
+        if (signingAccount) {
+          setConnectedAccount(signingAccount);
+        }
+      });
+    }
+  }, [storedConnectedAddress, walletsAccounts]);
 
   useEffect(() => {
     getWalletsAccounts().then((accounts: Record<string, SigningAccount>) => {

--- a/src/contexts/Wallets.tsx
+++ b/src/contexts/Wallets.tsx
@@ -60,7 +60,6 @@ const WalletProviderInner = ({ children }: { children: React.ReactNode }) => {
         }
       }
     }
-    console.log(walletState);
     _setWalletState(walletState);
   };
 

--- a/src/contexts/Wallets.tsx
+++ b/src/contexts/Wallets.tsx
@@ -4,16 +4,16 @@ import React, {
   useContext,
   useState,
   useEffect,
-} from "react";
-import { WalletAggregator, BaseWallet } from "@polkadot-onboard/core";
-import { InjectedWalletProvider } from "@polkadot-onboard/injected-wallets";
+} from 'react';
+import { WalletAggregator, BaseWallet } from '@polkadot-onboard/core';
+import { InjectedWalletProvider } from '@polkadot-onboard/injected-wallets';
 import {
   PolkadotWalletsContextProvider,
   useWallets as _useWallets,
-} from "@polkadot-onboard/react";
+} from '@polkadot-onboard/react';
 
-const APP_NAME = "Swipe to Vote";
-export type WalletState = "connected" | "disconnected";
+const APP_NAME = 'Swipe to Vote';
+export type WalletState = 'connected' | 'disconnected';
 export const useWallets = () => useContext(WalletContext);
 
 const WalletContext = createContext({});
@@ -54,9 +54,9 @@ const WalletProviderInner = ({ children }: { children: React.ReactNode }) => {
       let title = wallet.metadata?.title;
       if (title) {
         let state = WalletStateStorage.get(title);
-        if (state === "connected") {
+        if (state === 'connected') {
           await wallet.connect();
-          walletState[title] = "connected";
+          walletState[title] = 'connected';
         }
       }
     }
@@ -85,3 +85,4 @@ const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 };
 
 export default WalletProvider;
+


### PR DESCRIPTION
The connected wallets was not being loaded from local storage, hence the user will lose their connected wallets when they refresh the app.
These changes will set the initiate the connected wallets and accounts based on what is stored in localstorage.  