### PR TITLE
parse search params in correct order

### DIFF
--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -486,11 +486,12 @@ export function validateEnpoints(endpoints: string[]): Result<string[]> {
   return ok(endpoints);
 }
 
-function getSearchParams(search: string, params: string[]): string[] {
+function getSearchParams(
+  search: string,
+  params: string[]
+): Array<string | undefined> {
   const searchParams = new URLSearchParams(search);
-  return Array.from(searchParams.entries())
-    .filter(([key]) => params.includes(key))
-    .map(([, value]) => value);
+  return params.map((param) => searchParams.get(param) || undefined);
 }
 
 export type NetworkParams = {


### PR DESCRIPTION
there is an issue with getSearchParams for the case that param name does not exist in QS:
e.x. 
getSearchParams("?rpc=127.0.0.1:1234" , params: string[network, rpc] 
returns 
[127.0.0.1:1234] 
while expected 
[undefined, 127.0.0.1:1234]